### PR TITLE
A couple of fixes.

### DIFF
--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -534,25 +534,6 @@ class Trajectory(om.Group):
                     get_src_indices_by_row([num_ode_nodes-1], shapes[i])
                 flat_src_idxs[i] = True
 
-            #if MPI:
-                ## State/Parameter/Control dictionaries on phases are updated with new values for
-                ## shape and units, but we don't broadcast those to the off-ranks.
-                #all_ranks = self.comm.allgather(shapes[i])
-                #for item in all_ranks:
-                    #if item not in [None, _unspecified]:
-                        #shapes[i] = item
-                        #break
-                #else:
-                    #raise RuntimeError('Something is amiss.')
-
-                #all_ranks = self.comm.allgather(units[i])
-                #for item in all_ranks:
-                    #if item not in [None, _unspecified]:
-                        #units[i] = item
-                        #break
-                #else:
-                    #raise RuntimeError('Something is amiss.')
-
         linkage_options._src_a = sources['a']
         linkage_options._src_b = sources['b']
         linkage_options._src_idxs_a = src_idxs['a']

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
@@ -10,8 +10,8 @@ from dymos.transcriptions.runge_kutta.components.runge_kutta_k_iter_group import
 from dymos.transcriptions.runge_kutta.test.rk_test_ode import TestODE
 
 # Modify class so we can run it standalone.
-from dymos.utils.misc import CompWrapperConfig
-RungeKuttaKIterGroup = CompWrapperConfig(RungeKuttaKIterGroup)
+from dymos.utils.misc import GroupWrapperConfig
+RungeKuttaKIterGroup = GroupWrapperConfig(RungeKuttaKIterGroup)
 
 
 class TestRungeKuttaKIterGroup(unittest.TestCase):


### PR DESCRIPTION
### Summary

1. Under MPI, we need to broadcast the updated-interrogated size and units from their source rank to all ranks so that the trajectory has the correct sizes and units on all ranks.

2. Fixed a test to use the group config wrapper instead of the ones for components.

### Related Issues

- Resolves #

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
